### PR TITLE
Update the version number

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 Plugin Name: Time Zones ⏰
 Plugin URI: https://github.com/YOURLS/timezones
 Description: Tell YOURLS what timezone you are in
-Version: 1.0
+Version: 1.2.1
 Author: YOURLS contributors
 Author URI: https://yourls.org/
 */

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 Plugin Name: Time Zones ⏰
 Plugin URI: https://github.com/YOURLS/timezones
 Description: Tell YOURLS what timezone you are in
-Version: 1.2.1
+Version: 1.3
 Author: YOURLS contributors
 Author URI: https://yourls.org/
 */


### PR DESCRIPTION
When 1.2 was released, the version number in the comment header remained "1.0", so PUNS kept thinking there's a newer version available, which is mildly annoying. I'm bumping the version number to 1.2.1 just for this.